### PR TITLE
Add factory for unauthenticated AvanzaClient

### DIFF
--- a/src/main/kotlin/com/github/widarlein/kavanza/Avanza.kt
+++ b/src/main/kotlin/com/github/widarlein/kavanza/Avanza.kt
@@ -12,4 +12,13 @@ object Avanza {
      */
     fun connect(userCredentials: UserCredentials, totpSecret: String, debugPrintouts: Boolean = false): AvanzaClient =
         AvanzaClient(debugPrintouts).also { it.login(userCredentials, totpSecret) }
+
+    /**
+     * Returns an Avanza client without logging in. The client can be used for endpoints that don't
+     * require authentication, such as price charts and exchange rates. Calling endpoints that require
+     * authentication will fail.
+     *
+     * @return an unauthenticated Avanza client
+     */
+    fun unauthenticatedClient(debugPrintouts: Boolean = false): AvanzaClient = AvanzaClient(debugPrintouts)
 }


### PR DESCRIPTION
Some endpoints (e.g. price charts, exchange rates) don't require
authentication. Expose Avanza.unauthenticatedClient() so callers can
get a client without going through login/TOTP.

Not optimal solution, since calls are going to fail in backend, but it's something.
In the future there should probably be a client implementation that fails locally on operations that require authentication